### PR TITLE
Implement async bind

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -236,7 +236,7 @@
   version = "0.0.5"
 
 [[projects]]
-  digest = "1:65f55cb1d33a320785f7359dbb2f2c187ebb1075b76c70669154da76f0ea0f15"
+  digest = "1:1c4ac7153ef289026620c5e15a437ab3918ff1db0fce4d6a0176a5603259c41c"
   name = "github.com/pmorie/osb-broker-lib"
   packages = [
     "pkg/broker",
@@ -245,8 +245,7 @@
     "pkg/server",
   ]
   pruneopts = "NUT"
-  revision = "f4ca270ef323318b363f986229bd10bccb2d28b1"
-  version = "0.0.10"
+  revision = "87d71cfbf3427836e5623f1e3843a466348b7be6"
 
 [[projects]]
   digest = "1:03bca087b180bf24c4f9060775f137775550a0834e18f0bca0520a868679dbd7"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,7 @@ required = [
 
 [[constraint]]
   name = "github.com/pmorie/osb-broker-lib"
-  version = "0.0.10"
+  revision = "87d71cfbf3427836e5623f1e3843a466348b7be6"
 
 [[constraint]]
   branch = "update-boilerplate"

--- a/vendor/github.com/pmorie/osb-broker-lib/pkg/broker/interface.go
+++ b/vendor/github.com/pmorie/osb-broker-lib/pkg/broker/interface.go
@@ -120,6 +120,53 @@ type Interface interface {
 	//
 	// https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#binding
 	Bind(request *osb.BindRequest, c *RequestContext) (*BindResponse, error)
+	// GetBinding encapsulates the business logic that returns a binding in
+	// the form of a BindingResponse. The platform will only request a Binding
+	// if the broker's catalog has declared `"bindings_retrievable": true` for
+	// a particular service.
+	//
+	// The parameters are:
+	// - a osb.GetBindingRequest created from the original http request
+	// - a RequestContext object which encapsulates:
+	//    - a response writer, in case fine-grained control over the response is
+	//      required
+	//    - the original http request, in case access is required (to get special
+	//      request headers, for example)
+	//
+	// Implementers should return a GetBindingResponse for a successful operation
+	// or an error. The APISurface handles translating GetBindingResponses or
+	// errors into the correct form in the http response.
+	//
+	// For more information, see:
+	//
+	// https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#fetching-a-service-binding
+	GetBinding(request *osb.GetBindingRequest, c *RequestContext) (*GetBindingResponse, error)
+	// BindingLastOperation encapsulates the business logic for a last operation
+	// request and returns a osb.BindingLastOperationResponse or an error.
+	// BindingLastOperation is called when a platform checks the status of an ongoing
+	// asynchronous binding operation on an instance of a binding.
+	//
+	// NOTE: Asynchronous bindings are currently a proposal against the OSB spec
+	// that is in the "validating through implementation phase". For more information,
+	// see the PR: https://github.com/openservicebrokerapi/servicebroker/pull/334
+	//
+	// The parameters are:
+	// - a osb.BindingLastOperationRequest created from the original http request
+	// - a RequestContext object which encapsulates:
+	//    - a response writer, in case fine-grained control over the response is
+	//      required
+	//    - the original http request, in case access is required (to get special
+	//      request headers, for example)
+	//
+	// Implementers should return a BindingLastOperationResponse for a successful
+	// operation or an error. The APISurface handles translating
+	// BindingLastOperationResponses or errors into the correct form in the http
+	// response.
+	//
+	// For more information, see:
+	//
+	// https://github.com/mattmcneeney/servicebroker/blob/219bf56c58a2f37d4a1a1b1b49b6e0dcc9683167/spec.md#polling-last-operation-for-service-bindings
+	BindingLastOperation(request *osb.BindingLastOperationRequest, c *RequestContext) (*LastOperationResponse, error)
 	// Unbind encapsulates the business logic for an unbind operation and
 	// returns a osb.UnbindResponse or an error. Unbind deletes a binding and the
 	// resources associated with it.

--- a/vendor/github.com/pmorie/osb-broker-lib/pkg/broker/types.go
+++ b/vendor/github.com/pmorie/osb-broker-lib/pkg/broker/types.go
@@ -42,6 +42,11 @@ type BindResponse struct {
 	Exists bool `json:"-"`
 }
 
+// GetBinding is sent as the response to a get binding call.
+type GetBindingResponse struct {
+	osb.GetBindingResponse
+}
+
 // UnbindResponse is sent as the response to a bind call.
 type UnbindResponse struct {
 	osb.UnbindResponse

--- a/vendor/github.com/pmorie/osb-broker-lib/pkg/server/server.go
+++ b/vendor/github.com/pmorie/osb-broker-lib/pkg/server/server.go
@@ -57,6 +57,8 @@ func registerAPIHandlers(router *mux.Router, api *rest.APISurface) {
 	router.HandleFunc("/v2/service_instances/{instance_id}", api.DeprovisionHandler).Methods("DELETE")
 	router.HandleFunc("/v2/service_instances/{instance_id}", api.UpdateHandler).Methods("PATCH")
 	router.HandleFunc("/v2/service_instances/{instance_id}/service_bindings/{binding_id}", api.BindHandler).Methods("PUT")
+	router.HandleFunc("/v2/service_instances/{instance_id}/service_bindings/{binding_id}", api.GetBindingHandler).Methods("GET")
+	router.HandleFunc("/v2/service_instances/{instance_id}/service_bindings/{binding_id}/last_operation", api.BindingLastOperationHandler).Methods("GET")
 	router.HandleFunc("/v2/service_instances/{instance_id}/service_bindings/{binding_id}", api.UnbindHandler).Methods("DELETE")
 	router.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("OK"))


### PR DESCRIPTION
This implements async binding (and matching cleanup in async unbinding).

Since we do no work in unbinding anyway, it is always synchronous.

Note that this requires bumping osb-broker-lib to a version that supports async bind.