### PR TITLE
fix: wait for chart to be ready

### DIFF
--- a/pkg/tiller/tiller.go
+++ b/pkg/tiller/tiller.go
@@ -52,6 +52,7 @@ func (t *Client) Create(ch *chart.Chart, installNS string, values map[string]int
 		ReuseName:    true,
 		DisableHooks: false,
 		Values:       &chart.Config{Raw: string(valuesYaml)},
+		Wait:         true,
 	}
 	glog.Infof("installing release for chart %s\n%s", ch.Metadata.Name, spew.Sdump(req))
 	return rlsCl.InstallRelease(ctx, req)


### PR DESCRIPTION
A naive attempt to be more consistent on waiting for the underlying resource Helm creates.