### PR TITLE
refactor: shared labels template

### DIFF
--- a/charts/minibroker/templates/_helpers.tpl
+++ b/charts/minibroker/templates/_helpers.tpl
@@ -4,6 +4,17 @@
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "minibroker.fullname" -}}
 {{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Define the standard labels that will be applied to all objects in this chart.
+*/}}
+{{- define "minibroker.labels" }}
+  labels:
+    app: {{ template "minibroker.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/charts/minibroker/templates/_helpers.tpl
+++ b/charts/minibroker/templates/_helpers.tpl
@@ -11,10 +11,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Define the standard labels that will be applied to all objects in this chart.
 */}}
-{{- define "minibroker.labels" }}
-  labels:
-    app: {{ template "minibroker.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-{{- end }}
+{{- define "minibroker.labels" -}}
+app: {{ include "minibroker.fullname" . | quote }}
+chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+release: {{ .Release.Name | quote }}
+heritage: {{ .Release.Service | quote }}
+{{- end -}}

--- a/charts/minibroker/templates/broker.yaml
+++ b/charts/minibroker/templates/broker.yaml
@@ -3,11 +3,7 @@ apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceBroker
 metadata:
   name: minibroker
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  {{- template "minibroker.labels" . }}
 spec:
-  url: http://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  url: http://{{ template "minibroker.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 {{ end }}

--- a/charts/minibroker/templates/broker.yaml
+++ b/charts/minibroker/templates/broker.yaml
@@ -3,7 +3,8 @@ apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceBroker
 metadata:
   name: minibroker
-  {{- template "minibroker.labels" . }}
+  labels:
+    {{- include "minibroker.labels" . | nindent 4 }}
 spec:
   url: http://{{ template "minibroker.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 {{ end }}

--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -1,26 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ template "minibroker.fullname" . }}
+  {{- template "minibroker.labels" . }}
 spec:
   replicas: 1
   strategy:
     type: {{ .Values.deploymentStrategy }}
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "minibroker.fullname" . }}
   template:
     metadata:
-      labels:
-        app: {{ template "fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
-        heritage: "{{ .Release.Service }}"
+      {{- include "minibroker.labels" . | nindent 6 }}
     spec:
       serviceAccountName: minibroker
       containers:

--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -2,7 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "minibroker.fullname" . }}
-  {{- template "minibroker.labels" . }}
+  labels:
+    {{- include "minibroker.labels" . | nindent 4 }}
 spec:
   replicas: 1
   strategy:
@@ -12,7 +13,8 @@ spec:
       app: {{ template "minibroker.fullname" . }}
   template:
     metadata:
-      {{- include "minibroker.labels" . | nindent 6 }}
+      labels:
+        {{- include "minibroker.labels" . | nindent 8 }}
     spec:
       serviceAccountName: minibroker
       containers:

--- a/charts/minibroker/templates/rbac.yaml
+++ b/charts/minibroker/templates/rbac.yaml
@@ -6,10 +6,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.rbac.serviceAccount.name | quote }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "minibroker.labels" . | nindent 4 }}
     {{- range $k, $v := .Values.rbac.serviceAccount.labels }}
     {{ $k | quote }}: {{ $v | quote }}
     {{- end }}
@@ -33,10 +30,7 @@ kind: ClusterRole
 metadata:
   name: {{ printf "minibroker-%s" .Release.Name | quote }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "minibroker.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources:
@@ -50,10 +44,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ printf "minibroker-%s" .Release.Name | quote }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "minibroker.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -68,10 +59,7 @@ kind: Role
 metadata:
   name: minibroker
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "minibroker.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -82,10 +70,7 @@ kind: RoleBinding
 metadata:
   name: minibroker
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "minibroker.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -102,10 +87,7 @@ metadata:
   name: minibroker
   namespace: {{ $namespace | quote }}
   labels:
-    app: {{ template "fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    {{- include "minibroker.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["*"]
   resources: ["*"]
@@ -117,10 +99,7 @@ metadata:
   name: minibroker
   namespace: {{ $namespace | quote }}
   labels:
-    app: {{ template "fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    {{- include "minibroker.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -137,10 +116,7 @@ kind: ClusterRole
 metadata:
   name: {{ printf "minibroker-%s" .Release.Name | quote }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "minibroker.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources:
@@ -185,7 +161,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: minibroker
-  {{- template "minibroker.labels" . }}
+  labels:
+    {{- include "minibroker.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/minibroker/templates/rbac.yaml
+++ b/charts/minibroker/templates/rbac.yaml
@@ -185,11 +185,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: minibroker
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  {{- template "minibroker.labels" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/minibroker/templates/service.yaml
+++ b/charts/minibroker/templates/service.yaml
@@ -2,7 +2,8 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ template "minibroker.fullname" . }}
-  {{- template "minibroker.labels" . }}
+  labels:
+    {{- include "minibroker.labels" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "minibroker.fullname" . }}

--- a/charts/minibroker/templates/service.yaml
+++ b/charts/minibroker/templates/service.yaml
@@ -1,15 +1,11 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ template "minibroker.fullname" . }}
+  {{- template "minibroker.labels" . }}
 spec:
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "minibroker.fullname" . }}
   ports:
   - protocol: TCP
     port: 80


### PR DESCRIPTION
Cherry-picked the commit from https://github.com/SUSE/minibroker/pull/19, then applied some fixes to allow other labels to be set without having to set them in the template.