### PR TITLE
fix: no cluster admin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ jobs:
     stage: test-integration
     env:
     - CHANGE_MINIKUBE_NONE_USER=false
-    - MINIKUBE_WANTUPDATENOTIFICATION=false
     - MINIKUBE_HOME=${HOME}
     before_install:
     - sudo apt-get -qq -y install conntrack

--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,7 @@ test-unit:
 	go test -v ./cmd/... ./pkg/...
 
 test-integration:
-	-kubectl delete namespace minibroker-tests
-	kubectl create namespace minibroker-tests
 	(cd ./tests/integration; NAMESPACE=minibroker-tests ginkgo --nodes 4 --slowSpecThreshold 180 .)
-	kubectl delete namespace minibroker-tests
 
 test: test-unit test-integration test-wordpress
 

--- a/charts/minibroker/templates/rbac.yaml
+++ b/charts/minibroker/templates/rbac.yaml
@@ -10,13 +10,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    {{- if gt (len .Values.rbac.serviceAccount.labels) 0 }}
-    {{- .Values.rbac.serviceAccount.labels | toYaml | nindent 4 }}
-    {{- end }}{{/* if gt (len .Values.rbac.serviceAccount.labels) 0 */}}
+    {{- range $k, $v := .Values.rbac.serviceAccount.labels }}
+    {{ $k | quote }}: {{ $v | quote }}
+    {{- end }}
   annotations:
-    {{- if gt (len .Values.rbac.serviceAccount.annotations) 0 }}
-    {{- .Values.rbac.serviceAccount.annotations | toYaml | nindent 4 }}
-    {{- end }}{{/* if gt (len .Values.rbac.serviceAccount.annotations) 0 */}}
+    {{- range $k, $v := .Values.rbac.serviceAccount.annotations }}
+    {{ $k | quote }}: {{ $v | quote }}
+    {{- end }}
 {{- end }}{{/* if .Values.rbac.serviceAccount.create */}}
 
 {{- if .Values.rbac.namespaced.enabled }}
@@ -31,7 +31,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: minibroker
+  name: {{ printf "minibroker-%s" .Release.Name | quote }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -48,7 +48,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: minibroker
+  name: {{ printf "minibroker-%s" .Release.Name | quote }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -57,7 +57,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: minibroker
+  name: {{ printf "minibroker-%s" .Release.Name | quote }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.rbac.serviceAccount.name | quote }}
@@ -135,7 +135,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: minibroker
+  name: {{ printf "minibroker-%s" .Release.Name | quote }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -193,7 +193,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: minibroker
+  name: {{ printf "minibroker-%s" .Release.Name | quote }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.rbac.serviceAccount.name | quote }}

--- a/charts/minibroker/templates/rbac.yaml
+++ b/charts/minibroker/templates/rbac.yaml
@@ -1,5 +1,35 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.rbac.serviceAccount.create }}
+---
 apiVersion: v1
 kind: ServiceAccount
+metadata:
+  name: {{ .Values.rbac.serviceAccount.name | quote }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- if gt (len .Values.rbac.serviceAccount.labels) 0 }}
+    {{- .Values.rbac.serviceAccount.labels | toYaml | nindent 4 }}
+    {{- end }}{{/* if gt (len .Values.rbac.serviceAccount.labels) 0 */}}
+  annotations:
+    {{- if gt (len .Values.rbac.serviceAccount.annotations) 0 }}
+    {{- .Values.rbac.serviceAccount.annotations | toYaml | nindent 4 }}
+    {{- end }}{{/* if gt (len .Values.rbac.serviceAccount.annotations) 0 */}}
+{{- end }}{{/* if .Values.rbac.serviceAccount.create */}}
+
+{{- if .Values.rbac.namespaced.enabled }}
+{{/* Checks for when the rbac is namespaced. */}}
+{{- if .Values.defaultNamespace }}
+{{- if not has .Values.defaultNamespace .Values.rbac.namespaced.whitelist }}
+{{- fail "The default namespace is not whitelisted in rbac.namespaced.whitelist" }}
+{{- end }}{{/* if not has .Values.defaultNamespace .Values.rbac.namespaced.whitelist */}}
+{{- end }}{{/* if .Values.defaultNamespace */}}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   name: minibroker
   labels:
@@ -7,6 +37,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -20,8 +57,147 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: minibroker
 subjects:
 - kind: ServiceAccount
+  name: {{ .Values.rbac.serviceAccount.name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: minibroker
-  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minibroker
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: minibroker
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.rbac.serviceAccount.name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- range $namespace := .Values.rbac.namespaced.whitelist }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: minibroker
+  namespace: {{ $namespace | quote }}
+  labels:
+    app: {{ template "fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minibroker
+  namespace: {{ $namespace | quote }}
+  labels:
+    app: {{ template "fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: minibroker
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.rbac.serviceAccount.name | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+{{- end }}{{/* range $namespace := .Values.rbac.namespaced.whitelist */}}
+{{- else }}{{/* if .Values.rbac.namespaced.enabled */}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: minibroker
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - limitranges
+  - persistentvolumeclaims
+  - pods
+  - podtemplates
+  - replicationcontrollers
+  - resourcequotas
+  - secrets
+  - serviceaccounts
+  - services
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  - autoscaling
+  - batch
+  - networking.k8s.io
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs: ["*"]
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: minibroker
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minibroker
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.rbac.serviceAccount.name | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}{{/* if .Values.rbac.namespaced.enabled */}}
+
+{{- end }}{{/* if .Values.rbac.create */}}

--- a/charts/minibroker/values.yaml
+++ b/charts/minibroker/values.yaml
@@ -17,3 +17,21 @@ logLevel: 3
 serviceCatalogEnabledOnly: true
 
 deployServiceCatalog: true
+
+# A default namespace where Minibroker deploys service instances.
+defaultNamespace: ~
+
+rbac:
+  create: true
+  namespaced:
+    # Whether Minibroker will be namespaced or not. When enabled, Minibroker will only be able to
+    # manage resources in the whitelisted namespaces.
+    enabled: false
+    # A list of namespaces Minibroker can use to deploy service instances. The namespaces are
+    # expected to be created ahead of time.
+    whitelist: []
+  serviceAccount:
+    create: true
+    name: minibroker
+    annotations: {}
+    labels: {}

--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -17,5 +17,6 @@
 set -o errexit -o nounset -o pipefail
 
 VM_DRIVER=none sudo timeout 3m make create-cluster
+timeout 1m kubectl create namespace minibroker-tests
 timeout 5m make deploy
 timeout 5m make test-integration

--- a/hack/create-cluster.sh
+++ b/hack/create-cluster.sh
@@ -21,6 +21,8 @@ set -o errexit -o nounset -o pipefail
 : "${VM_MEMORY:=$(( 1024 * 4 ))}"
 : "${KUBERNETES_VERSION:=v1.15.12}"
 
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+
 if [[ "$(minikube status)" != *"Running"* ]]; then
     set -o xtrace
     minikube start \


### PR DESCRIPTION
Improving the RBAC so that Minibroker doesn't operate as cluster-admin. Also, the new API for RBAC allows disabling it completely or making it namespaced so that Minibroker will only be allowed to manage whitelisted namespaces.