### PR TITLE
fix: bump Travis timeout

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -18,5 +18,5 @@ set -o errexit -o nounset -o pipefail
 
 VM_DRIVER=none sudo timeout 3m make create-cluster
 timeout 1m kubectl create namespace minibroker-tests
-timeout 5m make deploy
+timeout 10m make deploy
 timeout 5m make test-integration


### PR DESCRIPTION
Other PRs started to fail on this timeout. Since this depends on various external network accesses, it seems prudent to bump the value to a way larger one.