### PR TITLE
fix: remove hardcoded cluster domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ possible to run the minibroker separately, but this would need a proper
 ingress setup.
 
 ```
-cf create-service-broker minibroker user pass http://minibroker-minibroker.minibroker.svc.cluster.local
+cf create-service-broker minibroker user pass http://minibroker-minibroker.minibroker.svc
 cf enable-service-access redis
 echo > redis.json '[{ "protocol": "tcp", "destination": "10.0.0.0/8", "ports": "6379", "description": "Allow Redis traffic" }]'
 cf create-security-group redis_networking redis.json
@@ -170,12 +170,12 @@ Parameters:
 
 Secret Data:
   database              mydb
-  host                  lucky-dragon-mysql.minibroker.svc.cluster.local
+  host                  lucky-dragon-mysql.minibroker.svc
   mysql-password        gsIpB8dBEn
   mysql-root-password   F8aBHuo8zb
   password              gsIpB8dBEn
   port                  3306
-  uri                   mysql://admin:gsIpB8dBEn@lucky-dragon-mysql.minibroker.svc.cluster.local:3306/mydb
+  uri                   mysql://admin:gsIpB8dBEn@lucky-dragon-mysql.minibroker.svc:3306/mydb
   username              admin
 
 $ svcat unbind mysqldb

--- a/charts/minibroker/templates/broker.yaml
+++ b/charts/minibroker/templates/broker.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "minibroker.labels" . | nindent 4 }}
 spec:
-  url: http://{{ template "minibroker.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  url: http://{{ template "minibroker.fullname" . }}.{{ .Release.Namespace }}.svc
 {{ end }}

--- a/pkg/minibroker/provider.go
+++ b/pkg/minibroker/provider.go
@@ -67,5 +67,5 @@ func buildURI(c Credentials) string {
 }
 
 func buildHostFromService(service corev1.Service) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", service.Name, service.Namespace)
+	return fmt.Sprintf("%s.%s.svc", service.Name, service.Namespace)
 }


### PR DESCRIPTION
The cluster domain can be different than `cluster.local`.

Fixes https://github.com/kubernetes-sigs/minibroker/issues/45.