### PR TITLE
update wordpress deployment

### DIFF
--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
   replicas: 1
   template:
     metadata:

--- a/charts/wordpress/templates/mysql-instance.yaml
+++ b/charts/wordpress/templates/mysql-instance.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   clusterServiceClassExternalName: mysql
   clusterServicePlanExternalName: {{ .Values.externalDatabase.minibroker.servicePlan }}
-  parameters:
   {{- if .Values.externalDatabase.minibroker.parameters }}
-  {{ toYaml .Values.externalDatabase.minibroker.parameters | indent 2 }}{{- end }}
-
+  parameters: {{ toJson .Values.externalDatabase.minibroker.parameters }}
+  {{- end }}

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -52,7 +52,7 @@ wordpressBlogName: User's Blog!
 externalDatabase:
   minibroker:
     ## The plan to request from Minibroker, use svcat get plans --class mysql to see your options
-    servicePlan: 5-7-14
+    servicePlan: 5-7-30
     parameters:
       mysqlDatabase: bitnami_wordpress
       mysqlUser: bn_wordpress


### PR DESCRIPTION
New versions of Kubernetes does not supports `extensions/v1beta1`:
```
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1"
```