### PR TITLE
fix: Do not run as root, use read-only filesystem

### DIFF
--- a/build/image.sh
+++ b/build/image.sh
@@ -21,4 +21,4 @@ if [[ "${BUILD_IN_MINIKUBE}" == "1" ]]; then
   eval $(minikube -p minikube docker-env)
 fi
 
-docker build --tag "${IMAGE}:${TAG}" --file image/Dockerfile .
+docker build --tag "${IMAGE}:${TAG}" --file docker/Dockerfile .

--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       - name: minibroker
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
         args:
         - minibroker
         {{- if .Values.serviceCatalogEnabledOnly }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,15 +64,17 @@ RUN cp lib/ca-bundle.crt /tmp/ca-bundle.crt
 # The running stage.
 FROM ${RUNNING_IMAGE}
 
-#RUN adduser -D minibroker
-#USER minibroker
-
 COPY --from=cert_builder /tmp/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
 COPY --from=downloader /tmp/dumb-init /usr/local/bin/dumb-init
 COPY --from=downloader /tmp/linux-amd64/helm /usr/local/bin/helm
-RUN helm init --client-only
-
 COPY --from=builder /build/minibroker/output/minibroker-linux /usr/local/bin/minibroker
 
+ADD docker/rootfs/etc/passwd /etc/passwd
+COPY --chown=1000 docker/rootfs/home/minibroker /home/minibroker
+USER 1000
+RUN helm init --client-only
+
+VOLUME /home/minibroker
+ENV TMPDIR /home/minibroker/tmp
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["minibroker", "--help"]

--- a/docker/rootfs/etc/passwd
+++ b/docker/rootfs/etc/passwd
@@ -1,0 +1,2 @@
+root:x:0:0:root:/root:/bin/bash
+minibroker:x:1000:1000::/home/minibroker:/bin/bash

--- a/docker/rootfs/etc/passwd
+++ b/docker/rootfs/etc/passwd
@@ -1,2 +1,1 @@
-root:x:0:0:root:/root:/bin/bash
 minibroker:x:1000:1000::/home/minibroker:/bin/bash


### PR DESCRIPTION
Note: The docker image artifacts had to be moved from image/ to docker/
because the "image" name is somehow special to "docker build", ADD
commands were not working from there.

Fixes #39