### PR TITLE
bump: integration tests timeout on CI

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -19,4 +19,4 @@ set -o errexit -o nounset -o pipefail
 VM_DRIVER=none sudo timeout 3m make create-cluster
 timeout 1m kubectl create namespace minibroker-tests
 timeout 10m make deploy
-timeout 5m make test-integration
+timeout 8m make test-integration


### PR DESCRIPTION
It's reasonable to assume the CI can sometimes degrade the performance and take longer to complete the integration tests.