### PR TITLE
feat: Add support for deploying rabbitmq

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ services:
 * mariadb
 * mongodb
 * redis
+* rabbitmq
 
 Minibroker has built-in support for these charts so that the credentials are formatted
 in a format that Service Catalog Ready charts expect.

--- a/pkg/minibroker/minibroker.go
+++ b/pkg/minibroker/minibroker.go
@@ -98,6 +98,7 @@ func NewClient(namespace string, serviceCatalogEnabledOnly bool) *Client {
 			"postgresql": PostgresProvider{},
 			"mongodb":    MongodbProvider{},
 			"redis":      RedisProvider{},
+			"rabbitmq":   RabbitmqProvider{},
 		},
 	}
 }

--- a/pkg/minibroker/rabbitmq.go
+++ b/pkg/minibroker/rabbitmq.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package minibroker
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type RabbitmqProvider struct{}
+
+func (p RabbitmqProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
+	service := services[0]
+
+	var amqpPort *corev1.ServicePort = nil
+	for _, port := range service.Spec.Ports {
+		if port.Name == "amqp" {
+			amqpPort = &port
+			break
+		}
+	}
+	if amqpPort == nil {
+		return nil, errors.Errorf("no amqp port found")
+	}
+
+	var password string
+	passwordVal, ok := chartSecrets["rabbitmq-password"]
+	if !ok {
+		return nil, errors.Errorf("password not found in secret keys")
+	}
+	password = passwordVal.(string)
+
+	host := buildHostFromService(service)
+	creds := Credentials{
+		Protocol: amqpPort.Name,
+		Port:     amqpPort.Port,
+		Host:     host,
+		Username: "user",
+		Password: password,
+		Database: "%2F",
+	}
+	creds.URI = buildURI(creds)
+
+	return &creds, nil
+}

--- a/pkg/minibroker/rabbitmq.go
+++ b/pkg/minibroker/rabbitmq.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const amqpProtocolName = "amqp"
+
 type RabbitmqProvider struct{}
 
 func (p RabbitmqProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
@@ -34,7 +36,7 @@ func (p RabbitmqProvider) Bind(services []corev1.Service, params map[string]inte
 
 	var amqpPort *corev1.ServicePort
 	for _, port := range service.Spec.Ports {
-		if port.Name == "amqp" {
+		if port.Name == amqpProtocolName {
 			amqpPort = &port
 			break
 		}
@@ -54,7 +56,7 @@ func (p RabbitmqProvider) Bind(services []corev1.Service, params map[string]inte
 
 	host := buildHostFromService(service)
 	creds := Credentials{
-		Protocol: amqpPort.Name,
+		Protocol: amqpProtocolName,
 		Port:     amqpPort.Port,
 		Host:     host,
 		Username: "user",

--- a/pkg/minibroker/rabbitmq.go
+++ b/pkg/minibroker/rabbitmq.go
@@ -17,6 +17,9 @@ limitations under the License.
 package minibroker
 
 import (
+	"fmt"
+	"net/url"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -56,9 +59,14 @@ func (p RabbitmqProvider) Bind(services []corev1.Service, params map[string]inte
 		Host:     host,
 		Username: "user",
 		Password: password,
-		Database: "%2F",
+		Database: "/",
 	}
-	creds.URI = buildURI(creds)
+	creds.URI = buildRabbitmqURI(creds)
 
 	return &creds, nil
+}
+
+func buildRabbitmqURI(c Credentials) string {
+	return fmt.Sprintf("%s://%s:%s@%s:%d/%s",
+		c.Protocol, c.Username, c.Password, c.Host, c.Port, url.QueryEscape(c.Database))
 }

--- a/tests/integration/resources/rabbitmq_client.tmpl.yaml
+++ b/tests/integration/resources/rabbitmq_client.tmpl.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rabbitmq-client
+spec:
+  containers:
+  - name: rabbitmq-client
+    image: toolbelt/amqp
+    imagePullPolicy: IfNotPresent
+    command: {{ .Command | toJson }}
+    env:
+    - name: DATABASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: {{ .SecretName }}
+          key: uri
+  restartPolicy: Never


### PR DESCRIPTION
This pr adds support for deploying rabbitmq.

It also fixes the problem of namespaces becoming undeletable if a chart was already deleted but minibroker still thinks it needs to clean up. I encountered a lot when running the integration tests.