### PR TITLE
fix: CI conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,15 @@ dist: bionic
 
 # Don't indent any line more than one level to avoid '\n' characters in the converter string,
 # which breaks the regex free-spacing modifier. Also, do NOT include comments in the regex string.
+# The logic:
+#   * Build on push to branches on forks that setup Travis - not tied to the
+#     kubernetes-sigs/minibroker Travis account.
+#   * Build on branch master that is not tagged.
+#   * Build on kubernetes-sigs/minibroker when a tag is present and the branch matches a semver
+#     string.
 if: >-
-  ((branch = master) AND (tag IS NOT present))
+  (repo != "kubernetes-sigs/minibroker")
+  OR ((branch = master) AND (tag IS NOT present))
   OR (
   (repo = "kubernetes-sigs/minibroker")
   AND (tag IS present)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,31 @@ go: 1.14.x
 os: linux
 dist: bionic
 
+if: &release_condition >-
+  (repo = "kubernetes-sigs/minibroker")
+  AND (tag IS present)
+  AND (branch ~= /^(?x)
+      v(0|[1-9][0-9]*)  # major
+      \.
+      (0|[1-9][0-9]*)  # minor
+      \.
+      (0|[1-9][0-9]*)  # patch
+      (?:
+        - # pre-release
+        (
+          (?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)
+          (?:\.
+            (?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)
+          )*
+        )
+      )?
+      # build
+      (?:\+([0-9a-zA-Z-]+
+        (?:\.[0-9a-zA-Z-]+)*
+      )
+    )?
+  $/)
+
 cache:
   directories:
   - ${HOME}/assets
@@ -60,27 +85,4 @@ stages:
 - test
 - test-integration
 - name: release
-  if: >-
-    (repo = "kubernetes-sigs/minibroker") AND
-    (tag IS present) AND
-    (branch ~= /^(?x)
-        v(0|[1-9][0-9]*)  # major
-        \.
-        (0|[1-9][0-9]*)  # minor
-        \.
-        (0|[1-9][0-9]*)  # patch
-        (?:
-          - # pre-release
-          (
-            (?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)
-            (?:\.
-              (?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)
-            )*
-          )
-        )?
-        # build
-        (?:\+([0-9a-zA-Z-]+
-          (?:\.[0-9a-zA-Z-]+)*
-        )
-      )?
-    $/)
+  if: *release_condition

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,30 +4,19 @@ go: 1.14.x
 os: linux
 dist: bionic
 
-if: &release_condition >-
+# Don't indent any line more than one level to avoid '\n' characters in the converter string,
+# which breaks the regex free-spacing modifier. Also, do NOT include comments in the regex string.
+if: >-
+  ((branch = master) AND (tag IS NOT present))
+  OR (
   (repo = "kubernetes-sigs/minibroker")
   AND (tag IS present)
   AND (branch ~= /^(?x)
-      v(0|[1-9][0-9]*)  # major
-      \.
-      (0|[1-9][0-9]*)  # minor
-      \.
-      (0|[1-9][0-9]*)  # patch
-      (?:
-        - # pre-release
-        (
-          (?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)
-          (?:\.
-            (?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)
-          )*
-        )
-      )?
-      # build
-      (?:\+([0-9a-zA-Z-]+
-        (?:\.[0-9a-zA-Z-]+)*
-      )
-    )?
+  v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)
+  (?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?
+  (?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?
   $/)
+  )
 
 cache:
   directories:
@@ -85,4 +74,4 @@ stages:
 - test
 - test-integration
 - name: release
-  if: *release_condition
+  if: (repo = "kubernetes-sigs/minibroker") AND (tag IS present) AND (branch != master)


### PR DESCRIPTION
The current conditions are not doing exactly what we intend. It misses a top-level condition to also trigger the tags.

Tested with [travis-conditions](https://github.com/travis-ci/travis-conditions):
- `{"tag": "", "branch": "master", "repo": "kubernetes-sigs/minibroker"}` - should validate.
- `{"tag": "v1.0.0-rc1", "branch": "v1.0.0-rc1", "repo": "kubernetes-sigs/minibroker"}` - should validate.
- `{"tag": "", "branch": "v1.0.0-rc1", "repo": "kubernetes-sigs/minibroker"}` - should invalidate.