### PR TITLE
fix: protocol names on bind credentials

### DIFF
--- a/pkg/minibroker/mariadb.go
+++ b/pkg/minibroker/mariadb.go
@@ -21,6 +21,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const mariadbProtocolName = "mysql"
+
 type MariadbProvider struct{}
 
 func (p MariadbProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
@@ -64,7 +66,7 @@ func (p MariadbProvider) Bind(services []corev1.Service, params map[string]inter
 	}
 
 	creds := Credentials{
-		Protocol: svcPort.Name,
+		Protocol: mariadbProtocolName,
 		Port:     svcPort.Port,
 		Host:     host,
 		Username: user,

--- a/pkg/minibroker/mongodb.go
+++ b/pkg/minibroker/mongodb.go
@@ -21,6 +21,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const mongodbProtocolName = "mongodb"
+
 type MongodbProvider struct{}
 
 func (p MongodbProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
@@ -59,7 +61,7 @@ func (p MongodbProvider) Bind(services []corev1.Service, params map[string]inter
 	}
 
 	creds := Credentials{
-		Protocol: svcPort.Name,
+		Protocol: mongodbProtocolName,
 		Port:     svcPort.Port,
 		Host:     host,
 		Username: user,

--- a/pkg/minibroker/mysql.go
+++ b/pkg/minibroker/mysql.go
@@ -21,6 +21,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const mysqlProtocolName = "mysql"
+
 type MySQLProvider struct{}
 
 func (p MySQLProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
@@ -59,7 +61,7 @@ func (p MySQLProvider) Bind(services []corev1.Service, params map[string]interfa
 	}
 
 	creds := Credentials{
-		Protocol: svcPort.Name,
+		Protocol: mysqlProtocolName,
 		Port:     svcPort.Port,
 		Host:     host,
 		Username: user,

--- a/pkg/minibroker/postgres.go
+++ b/pkg/minibroker/postgres.go
@@ -21,6 +21,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const postgresqlProtocolName = "postgresql"
+
 type PostgresProvider struct{}
 
 func (p PostgresProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
@@ -59,7 +61,7 @@ func (p PostgresProvider) Bind(services []corev1.Service, params map[string]inte
 	password = passwordVal.(string)
 
 	creds := Credentials{
-		Protocol: svcPort.Name,
+		Protocol: postgresqlProtocolName,
 		Port:     svcPort.Port,
 		Host:     host,
 		Username: user,

--- a/pkg/minibroker/redis.go
+++ b/pkg/minibroker/redis.go
@@ -21,6 +21,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const redisProtocolName = "redis"
+
 type RedisProvider struct{}
 
 func (p RedisProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
@@ -50,7 +52,7 @@ func (p RedisProvider) Bind(services []corev1.Service, params map[string]interfa
 	password = passwordVal.(string)
 
 	creds := Credentials{
-		Protocol: svcPort.Name,
+		Protocol: redisProtocolName,
 		Port:     svcPort.Port,
 		Host:     host,
 		Password: password,


### PR DESCRIPTION
The protocol names are constants and should never rely on the name of the service port.