### PR TITLE
refactor: improve Provider logic

### DIFF
--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kubernetes-sigs/minibroker/pkg/broker"
 	"github.com/kubernetes-sigs/minibroker/pkg/broker/mocks"
+	"github.com/kubernetes-sigs/minibroker/pkg/minibroker"
 )
 
 //go:generate mockgen -destination=./mocks/mock_broker.go -package=mocks github.com/kubernetes-sigs/minibroker/pkg/broker MinibrokerClient
@@ -80,12 +81,12 @@ var _ = Describe("Broker", func() {
 
 	Describe("Provision", func() {
 		var (
-			provisionParams = map[string]interface{}{
+			provisionParams = minibroker.NewProvisionParams(map[string]interface{}{
 				"key": "value",
-			}
+			})
 			provisionRequest = &osb.ProvisionRequest{
 				ServiceID:  "redis",
-				Parameters: provisionParams,
+				Parameters: provisionParams.Object,
 			}
 			requestContext = &osbbroker.RequestContext{}
 		)
@@ -113,7 +114,7 @@ var _ = Describe("Broker", func() {
 					provisionRequest.ServiceID = service
 					provisioningSettings, found := provisioningSettings.ForService(service)
 					Expect(found).To(BeTrue())
-					params := provisioningSettings.OverrideParams
+					params := minibroker.NewProvisionParams(provisioningSettings.OverrideParams)
 
 					mbclient.EXPECT().
 						Provision(gomock.Any(), gomock.Eq(service), gomock.Any(), gomock.Eq(namespace), gomock.Any(), gomock.Eq(params))

--- a/pkg/broker/mocks/mock_broker.go
+++ b/pkg/broker/mocks/mock_broker.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	minibroker "github.com/kubernetes-sigs/minibroker/pkg/minibroker"
 	v2 "github.com/pmorie/go-open-service-broker-client/v2"
 	reflect "reflect"
 )
@@ -34,7 +35,7 @@ func (m *MockMinibrokerClient) EXPECT() *MockMinibrokerClientMockRecorder {
 }
 
 // Bind mocks base method
-func (m *MockMinibrokerClient) Bind(arg0, arg1, arg2 string, arg3 bool, arg4 map[string]interface{}) (string, error) {
+func (m *MockMinibrokerClient) Bind(arg0, arg1, arg2 string, arg3 bool, arg4 *minibroker.BindParams) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bind", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
@@ -138,7 +139,7 @@ func (mr *MockMinibrokerClientMockRecorder) ListServices() *gomock.Call {
 }
 
 // Provision mocks base method
-func (m *MockMinibrokerClient) Provision(arg0, arg1, arg2, arg3 string, arg4 bool, arg5 map[string]interface{}) (string, error) {
+func (m *MockMinibrokerClient) Provision(arg0, arg1, arg2, arg3 string, arg4 bool, arg5 *minibroker.ProvisionParams) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Provision", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(string)

--- a/pkg/minibroker/mariadb.go
+++ b/pkg/minibroker/mariadb.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/minibroker/mariadb.go
+++ b/pkg/minibroker/mariadb.go
@@ -33,8 +33,8 @@ type MariadbProvider struct{}
 
 func (p MariadbProvider) Bind(
 	services []corev1.Service,
-	_ BindParams,
-	provisionParams ProvisionParams,
+	_ *BindParams,
+	provisionParams *ProvisionParams,
 	chartSecrets Object,
 ) (Object, error) {
 	service := services[0]

--- a/pkg/minibroker/mariadb.go
+++ b/pkg/minibroker/mariadb.go
@@ -45,8 +45,14 @@ func (p MariadbProvider) Bind(
 
 	host := buildHostFromService(service)
 
-	database := provisionParams.DigStringOr("db.name", "")
-	user := provisionParams.DigStringOr("db.user", rootMariadbUsername)
+	database, err := provisionParams.DigStringOr("db.name", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database name: %w", err)
+	}
+	user, err := provisionParams.DigStringOr("db.user", rootMariadbUsername)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get username: %w", err)
+	}
 
 	var passwordKey string
 	if user == rootMariadbUsername {

--- a/pkg/minibroker/mariadb.go
+++ b/pkg/minibroker/mariadb.go
@@ -62,14 +62,7 @@ func (p MariadbProvider) Bind(
 	}
 	password, err := chartSecrets.DigString(passwordKey)
 	if err != nil {
-		switch err {
-		case ErrDigNotFound:
-			return nil, fmt.Errorf("password not found in secret keys")
-		case ErrDigNotString:
-			return nil, fmt.Errorf("password not a string")
-		default:
-			return nil, err
-		}
+		return nil, fmt.Errorf("failed to get password: %w", err)
 	}
 
 	creds := Object{

--- a/pkg/minibroker/mariadb.go
+++ b/pkg/minibroker/mariadb.go
@@ -17,15 +17,26 @@ limitations under the License.
 package minibroker
 
 import (
+	"fmt"
+	"net/url"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
 
-const mariadbProtocolName = "mysql"
+const (
+	mariadbProtocolName = "mysql"
+	rootMariadbUsername = "root"
+)
 
 type MariadbProvider struct{}
 
-func (p MariadbProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
+func (p MariadbProvider) Bind(
+	services []corev1.Service,
+	_ BindParams,
+	provisionParams ProvisionParams,
+	chartSecrets Object,
+) (Object, error) {
 	service := services[0]
 	if len(service.Spec.Ports) == 0 {
 		return nil, errors.Errorf("no ports found")
@@ -34,58 +45,41 @@ func (p MariadbProvider) Bind(services []corev1.Service, params map[string]inter
 
 	host := buildHostFromService(service)
 
-	dbParams, ok := params["db"].(map[string]interface{})
-	if !ok {
-		dbParams = make(map[string]interface{})
-	}
+	database := provisionParams.DigStringOr("db.name", "")
+	user := provisionParams.DigStringOr("db.user", rootMariadbUsername)
 
-	database := ""
-	dbVal, ok := dbParams["name"]
-	if ok {
-		database, ok = dbVal.(string)
-		if !ok {
-			return nil, errors.Errorf("db.name not a string")
-		}
-	}
-
-	var user, password string
-	userVal, ok := dbParams["user"]
-	if ok {
-		user, ok = userVal.(string)
-		if !ok {
-			return nil, errors.Errorf("db.user not a string")
-		}
-
-		passwordVal, ok := chartSecrets["mariadb-password"]
-		if !ok {
-			return nil, errors.Errorf("mariadb-password not found in secret keys")
-		}
-		password, ok = passwordVal.(string)
-		if !ok {
-			return nil, errors.Errorf("password not a string")
-		}
+	var passwordKey string
+	if user == rootMariadbUsername {
+		passwordKey = "mariadb-root-password"
 	} else {
-		user = "root"
-
-		rootPassword, ok := chartSecrets["mariadb-root-password"]
-		if !ok {
-			return nil, errors.Errorf("mariadb-root-password not found in secret keys")
-		}
-		password, ok = rootPassword.(string)
-		if !ok {
-			return nil, errors.Errorf("password not a string")
+		passwordKey = "mariadb-password"
+	}
+	password, err := chartSecrets.DigString(passwordKey)
+	if err != nil {
+		switch err {
+		case ErrDigNotFound:
+			return nil, fmt.Errorf("password not found in secret keys")
+		case ErrDigNotString:
+			return nil, fmt.Errorf("password not a string")
+		default:
+			return nil, err
 		}
 	}
 
-	creds := Credentials{
-		Protocol: mariadbProtocolName,
-		Port:     svcPort.Port,
-		Host:     host,
-		Username: user,
-		Password: password,
-		Database: database,
+	creds := Object{
+		"protocol": mariadbProtocolName,
+		"port":     svcPort.Port,
+		"host":     host,
+		"username": user,
+		"password": password,
+		"database": database,
+		"uri": (&url.URL{
+			Scheme: mariadbProtocolName,
+			User:   url.UserPassword(user, password),
+			Host:   fmt.Sprintf("%s:%d", host, svcPort.Port),
+			Path:   database,
+		}).String(),
 	}
-	creds.URI = buildURI(creds)
 
-	return &creds, nil
+	return creds, nil
 }

--- a/pkg/minibroker/minibroker.go
+++ b/pkg/minibroker/minibroker.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/minibroker/minibroker_test.go
+++ b/pkg/minibroker/minibroker_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/minibroker/mongodb.go
+++ b/pkg/minibroker/mongodb.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/minibroker/mongodb.go
+++ b/pkg/minibroker/mongodb.go
@@ -45,8 +45,14 @@ func (p MongodbProvider) Bind(
 
 	host := buildHostFromService(service)
 
-	database := provisionParams.DigStringOr("mongodbDatabase", "")
-	user := provisionParams.DigStringOr("mongodbUsername", rootMongodbUsername)
+	database, err := provisionParams.DigStringOr("mongodbDatabase", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database name: %w", err)
+	}
+	user, err := provisionParams.DigStringOr("mongodbUsername", rootMongodbUsername)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get username: %w", err)
+	}
 
 	var passwordKey string
 	if user == rootMongodbUsername {

--- a/pkg/minibroker/mongodb.go
+++ b/pkg/minibroker/mongodb.go
@@ -62,14 +62,7 @@ func (p MongodbProvider) Bind(
 	}
 	password, err := chartSecrets.DigString(passwordKey)
 	if err != nil {
-		switch err {
-		case ErrDigNotFound:
-			return nil, fmt.Errorf("password not found in secret keys")
-		case ErrDigNotString:
-			return nil, fmt.Errorf("password not a string")
-		default:
-			return nil, err
-		}
+		return nil, fmt.Errorf("failed to get password: %w", err)
 	}
 
 	creds := Object{

--- a/pkg/minibroker/mongodb.go
+++ b/pkg/minibroker/mongodb.go
@@ -17,15 +17,26 @@ limitations under the License.
 package minibroker
 
 import (
+	"fmt"
+	"net/url"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
 
-const mongodbProtocolName = "mongodb"
+const (
+	mongodbProtocolName = "mongodb"
+	rootMongodbUsername = "root"
+)
 
 type MongodbProvider struct{}
 
-func (p MongodbProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
+func (p MongodbProvider) Bind(
+	services []corev1.Service,
+	_ BindParams,
+	provisionParams ProvisionParams,
+	chartSecrets Object,
+) (Object, error) {
 	service := services[0]
 	if len(service.Spec.Ports) == 0 {
 		return nil, errors.Errorf("no ports found")
@@ -34,53 +45,41 @@ func (p MongodbProvider) Bind(services []corev1.Service, params map[string]inter
 
 	host := buildHostFromService(service)
 
-	database := ""
-	dbVal, ok := params["mongodbDatabase"]
-	if ok {
-		database, ok = dbVal.(string)
-		if !ok {
-			return nil, errors.Errorf("mongodbDatabase not a string")
-		}
-	}
+	database := provisionParams.DigStringOr("mongodbDatabase", "")
+	user := provisionParams.DigStringOr("mongodbUsername", rootMongodbUsername)
 
-	var user, password string
-	userVal, ok := params["mongodbUsername"]
-	if ok {
-		user, ok = userVal.(string)
-		if !ok {
-			return nil, errors.Errorf("mongodbUsername not a string")
-		}
-
-		passwordVal, ok := chartSecrets["mongodb-password"]
-		if !ok {
-			return nil, errors.Errorf("mongodb-password not found in secret keys")
-		}
-		password, ok = passwordVal.(string)
-		if !ok {
-			return nil, errors.Errorf("password not a string")
-		}
+	var passwordKey string
+	if user == rootMongodbUsername {
+		passwordKey = "mongodb-root-password"
 	} else {
-		user = "root"
-
-		rootPassword, ok := chartSecrets["mongodb-root-password"]
-		if !ok {
-			return nil, errors.Errorf("mongodb-root-password not found in secret keys")
-		}
-		password, ok = rootPassword.(string)
-		if !ok {
-			return nil, errors.Errorf("password not a string")
+		passwordKey = "mongodb-password"
+	}
+	password, err := chartSecrets.DigString(passwordKey)
+	if err != nil {
+		switch err {
+		case ErrDigNotFound:
+			return nil, fmt.Errorf("password not found in secret keys")
+		case ErrDigNotString:
+			return nil, fmt.Errorf("password not a string")
+		default:
+			return nil, err
 		}
 	}
 
-	creds := Credentials{
-		Protocol: mongodbProtocolName,
-		Port:     svcPort.Port,
-		Host:     host,
-		Username: user,
-		Password: password,
-		Database: database,
+	creds := Object{
+		"protocol": mongodbProtocolName,
+		"port":     svcPort.Port,
+		"host":     host,
+		"username": user,
+		"password": password,
+		"database": database,
+		"uri": (&url.URL{
+			Scheme: mongodbProtocolName,
+			User:   url.UserPassword(user, password),
+			Host:   fmt.Sprintf("%s:%d", host, svcPort.Port),
+			Path:   database,
+		}).String(),
 	}
-	creds.URI = buildURI(creds)
 
-	return &creds, nil
+	return creds, nil
 }

--- a/pkg/minibroker/mongodb.go
+++ b/pkg/minibroker/mongodb.go
@@ -33,8 +33,8 @@ type MongodbProvider struct{}
 
 func (p MongodbProvider) Bind(
 	services []corev1.Service,
-	_ BindParams,
-	provisionParams ProvisionParams,
+	_ *BindParams,
+	provisionParams *ProvisionParams,
 	chartSecrets Object,
 ) (Object, error) {
 	service := services[0]

--- a/pkg/minibroker/mysql.go
+++ b/pkg/minibroker/mysql.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/minibroker/mysql.go
+++ b/pkg/minibroker/mysql.go
@@ -17,15 +17,26 @@ limitations under the License.
 package minibroker
 
 import (
+	"fmt"
+	"net/url"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
 
-const mysqlProtocolName = "mysql"
+const (
+	mysqlProtocolName = "mysql"
+	rootMysqlUsername = "root"
+)
 
 type MySQLProvider struct{}
 
-func (p MySQLProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
+func (p MySQLProvider) Bind(
+	services []corev1.Service,
+	_ BindParams,
+	provisionParams ProvisionParams,
+	chartSecrets Object,
+) (Object, error) {
 	service := services[0]
 	if len(service.Spec.Ports) == 0 {
 		return nil, errors.Errorf("no ports found")
@@ -34,53 +45,41 @@ func (p MySQLProvider) Bind(services []corev1.Service, params map[string]interfa
 
 	host := buildHostFromService(service)
 
-	database := ""
-	dbVal, ok := params["mysqlDatabase"]
-	if ok {
-		database, ok = dbVal.(string)
-		if !ok {
-			return nil, errors.Errorf("mysqlDatabase not a string")
-		}
-	}
+	database := provisionParams.DigStringOr("mysqlDatabase", "")
+	user := provisionParams.DigStringOr("mysqlUser", rootMysqlUsername)
 
-	var user, password string
-	userVal, ok := params["mysqlUser"]
-	if ok {
-		user, ok = userVal.(string)
-		if !ok {
-			return nil, errors.Errorf("mysqlUser not a string")
-		}
-
-		passwordVal, ok := chartSecrets["mysql-password"]
-		if !ok {
-			return nil, errors.Errorf("mysql-password not found in secret keys")
-		}
-		password, ok = passwordVal.(string)
-		if !ok {
-			return nil, errors.Errorf("password not a string")
-		}
+	var passwordKey string
+	if user == rootMysqlUsername {
+		passwordKey = "mysql-root-password"
 	} else {
-		user = "root"
-
-		rootPassword, ok := chartSecrets["mysql-root-password"]
-		if !ok {
-			return nil, errors.Errorf("mysql-root-password not found in secret keys")
-		}
-		password, ok = rootPassword.(string)
-		if !ok {
-			return nil, errors.Errorf("password not a string")
+		passwordKey = "mysql-password"
+	}
+	password, err := chartSecrets.DigString(passwordKey)
+	if err != nil {
+		switch err {
+		case ErrDigNotFound:
+			return nil, fmt.Errorf("password not found in secret keys")
+		case ErrDigNotString:
+			return nil, fmt.Errorf("password not a string")
+		default:
+			return nil, err
 		}
 	}
 
-	creds := Credentials{
-		Protocol: mysqlProtocolName,
-		Port:     svcPort.Port,
-		Host:     host,
-		Username: user,
-		Password: password,
-		Database: database,
+	creds := Object{
+		"protocol": mysqlProtocolName,
+		"port":     svcPort.Port,
+		"host":     host,
+		"username": user,
+		"password": password,
+		"database": database,
+		"uri": (&url.URL{
+			Scheme: mysqlProtocolName,
+			User:   url.UserPassword(user, password),
+			Host:   fmt.Sprintf("%s:%d", host, svcPort.Port),
+			Path:   database,
+		}).String(),
 	}
-	creds.URI = buildURI(creds)
 
-	return &creds, nil
+	return creds, nil
 }

--- a/pkg/minibroker/mysql.go
+++ b/pkg/minibroker/mysql.go
@@ -33,8 +33,8 @@ type MySQLProvider struct{}
 
 func (p MySQLProvider) Bind(
 	services []corev1.Service,
-	_ BindParams,
-	provisionParams ProvisionParams,
+	_ *BindParams,
+	provisionParams *ProvisionParams,
 	chartSecrets Object,
 ) (Object, error) {
 	service := services[0]

--- a/pkg/minibroker/mysql.go
+++ b/pkg/minibroker/mysql.go
@@ -45,8 +45,14 @@ func (p MySQLProvider) Bind(
 
 	host := buildHostFromService(service)
 
-	database := provisionParams.DigStringOr("mysqlDatabase", "")
-	user := provisionParams.DigStringOr("mysqlUser", rootMysqlUsername)
+	database, err := provisionParams.DigStringOr("mysqlDatabase", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database name: %w", err)
+	}
+	user, err := provisionParams.DigStringOr("mysqlUser", rootMysqlUsername)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get username: %w", err)
+	}
 
 	var passwordKey string
 	if user == rootMysqlUsername {

--- a/pkg/minibroker/mysql.go
+++ b/pkg/minibroker/mysql.go
@@ -62,14 +62,7 @@ func (p MySQLProvider) Bind(
 	}
 	password, err := chartSecrets.DigString(passwordKey)
 	if err != nil {
-		switch err {
-		case ErrDigNotFound:
-			return nil, fmt.Errorf("password not found in secret keys")
-		case ErrDigNotString:
-			return nil, fmt.Errorf("password not a string")
-		default:
-			return nil, err
-		}
+		return nil, fmt.Errorf("failed to get password: %w", err)
 	}
 
 	creds := Object{

--- a/pkg/minibroker/postgres.go
+++ b/pkg/minibroker/postgres.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/minibroker/postgres.go
+++ b/pkg/minibroker/postgres.go
@@ -33,8 +33,8 @@ type PostgresProvider struct{}
 
 func (p PostgresProvider) Bind(
 	services []corev1.Service,
-	_ BindParams,
-	provisionParams ProvisionParams,
+	_ *BindParams,
+	provisionParams *ProvisionParams,
 	chartSecrets Object,
 ) (Object, error) {
 	service := services[0]

--- a/pkg/minibroker/postgres.go
+++ b/pkg/minibroker/postgres.go
@@ -45,16 +45,22 @@ func (p PostgresProvider) Bind(
 
 	host := buildHostFromService(service)
 
-	database := provisionParams.DigStringOr(
-		"postgresqlDatabase",
+	database, err := provisionParams.DigStringAltOr(
 		// Some older chart versions use postgresDatabase instead of postgresqlDatabase.
-		provisionParams.DigStringOr("postgresDatabase", ""),
+		[]string{"postgresqlDatabase", "postgresDatabase"},
+		"",
 	)
-	user := provisionParams.DigStringOr(
-		"postgresqlUsername",
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database name: %w", err)
+	}
+	user, err := provisionParams.DigStringAltOr(
 		// Some older chart versions use postgresUsername instead of postgresqlUsername.
-		provisionParams.DigStringOr("postgresUsername", defaultPostgresqlUsername),
+		[]string{"postgresqlUsername", "postgresUsername"},
+		defaultPostgresqlUsername,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get username: %w", err)
+	}
 
 	var passwordKey, altPasswordKey string
 	// postgresql-postgres-password is used when postgresqlPostgresPassword is set and

--- a/pkg/minibroker/postgres.go
+++ b/pkg/minibroker/postgres.go
@@ -75,14 +75,7 @@ func (p PostgresProvider) Bind(
 	}
 	password, err := chartSecrets.DigStringAlt([]string{passwordKey, altPasswordKey})
 	if err != nil {
-		switch err {
-		case ErrDigNotFound:
-			return nil, fmt.Errorf("password not found in secret keys")
-		case ErrDigNotString:
-			return nil, fmt.Errorf("password not a string")
-		default:
-			return nil, err
-		}
+		return nil, fmt.Errorf("failed to get password: %w", err)
 	}
 
 	creds := Object{

--- a/pkg/minibroker/postgres.go
+++ b/pkg/minibroker/postgres.go
@@ -73,21 +73,11 @@ func (p PostgresProvider) Bind(
 		// See https://github.com/kubernetes-sigs/minibroker/issues/17
 		altPasswordKey = "postgres-password"
 	}
-	password, err := chartSecrets.DigString(passwordKey)
+	password, err := chartSecrets.DigStringAlt([]string{passwordKey, altPasswordKey})
 	if err != nil {
 		switch err {
 		case ErrDigNotFound:
-			password, err = chartSecrets.DigString(altPasswordKey)
-			if err != nil {
-				switch err {
-				case ErrDigNotFound:
-					return nil, fmt.Errorf("password not found in secret keys")
-				case ErrDigNotString:
-					return nil, fmt.Errorf("password not a string")
-				default:
-					return nil, err
-				}
-			}
+			return nil, fmt.Errorf("password not found in secret keys")
 		case ErrDigNotString:
 			return nil, fmt.Errorf("password not a string")
 		default:

--- a/pkg/minibroker/postgres.go
+++ b/pkg/minibroker/postgres.go
@@ -17,15 +17,26 @@ limitations under the License.
 package minibroker
 
 import (
+	"fmt"
+	"net/url"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
 
-const postgresqlProtocolName = "postgresql"
+const (
+	postgresqlProtocolName    = "postgresql"
+	defaultPostgresqlUsername = "postgres"
+)
 
 type PostgresProvider struct{}
 
-func (p PostgresProvider) Bind(services []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error) {
+func (p PostgresProvider) Bind(
+	services []corev1.Service,
+	_ BindParams,
+	provisionParams ProvisionParams,
+	chartSecrets Object,
+) (Object, error) {
 	service := services[0]
 	if len(service.Spec.Ports) == 0 {
 		return nil, errors.Errorf("no ports found")
@@ -34,72 +45,64 @@ func (p PostgresProvider) Bind(services []corev1.Service, params map[string]inte
 
 	host := buildHostFromService(service)
 
-	dbVal, ok := params["postgresqlDatabase"]
-	if !ok {
+	database := provisionParams.DigStringOr(
+		"postgresqlDatabase",
 		// Some older chart versions use postgresDatabase instead of postgresqlDatabase.
-		dbVal, ok = params["postgresDatabase"]
-		if !ok {
-			dbVal = ""
-		}
-	}
-	database, ok := dbVal.(string)
-	if !ok {
-		return nil, errors.Errorf("database not a string")
-	}
-
-	userVal, ok := params["postgresqlUsername"]
-	if !ok {
+		provisionParams.DigStringOr("postgresDatabase", ""),
+	)
+	user := provisionParams.DigStringOr(
+		"postgresqlUsername",
 		// Some older chart versions use postgresUsername instead of postgresqlUsername.
-		userVal, ok = params["postgresUsername"]
-		if !ok {
-			userVal = "postgres"
-		}
-	}
-	user, ok := userVal.(string)
-	if !ok {
-		return nil, errors.Errorf("username not a string")
-	}
+		provisionParams.DigStringOr("postgresUsername", defaultPostgresqlUsername),
+	)
 
-	var password string
-	if user != "postgres" {
-		// postgresql-postgres-password is used when postgresqlPostgresPassword is set and
-		// postgresqlUsername is not 'postgres'.
-		passwordVal, ok := chartSecrets["postgresql-postgres-password"]
-		if !ok {
-			passwordVal, ok = chartSecrets["postgresql-password"]
-			if !ok {
-				return nil, errors.Errorf("password not found in secret keys")
-			}
-		}
-		password, ok = passwordVal.(string)
-		if !ok {
-			return nil, errors.Errorf("password not a string")
-		}
+	var passwordKey, altPasswordKey string
+	// postgresql-postgres-password is used when postgresqlPostgresPassword is set and
+	// postgresqlUsername is not 'postgres'.
+	if _, ok := provisionParams.Dig("postgresqlPostgresPassword"); ok && user != defaultPostgresqlUsername {
+		passwordKey = "postgresql-postgres-password"
 	} else {
-		passwordVal, ok := chartSecrets["postgresql-password"]
-		if !ok {
-			// Chart versions <2.0 use postgres-password instead of postgresql-password.
-			// See https://github.com/kubernetes-sigs/minibroker/issues/17
-			passwordVal, ok = chartSecrets["postgres-password"]
-			if !ok {
-				return nil, errors.Errorf("password not found in secret keys")
+		passwordKey = "postgresql-password"
+		// Chart versions <2.0 use postgres-password instead of postgresql-password.
+		// See https://github.com/kubernetes-sigs/minibroker/issues/17
+		altPasswordKey = "postgres-password"
+	}
+	password, err := chartSecrets.DigString(passwordKey)
+	if err != nil {
+		switch err {
+		case ErrDigNotFound:
+			password, err = chartSecrets.DigString(altPasswordKey)
+			if err != nil {
+				switch err {
+				case ErrDigNotFound:
+					return nil, fmt.Errorf("password not found in secret keys")
+				case ErrDigNotString:
+					return nil, fmt.Errorf("password not a string")
+				default:
+					return nil, err
+				}
 			}
-		}
-		password, ok = passwordVal.(string)
-		if !ok {
-			return nil, errors.Errorf("password not a string")
+		case ErrDigNotString:
+			return nil, fmt.Errorf("password not a string")
+		default:
+			return nil, err
 		}
 	}
 
-	creds := Credentials{
-		Protocol: postgresqlProtocolName,
-		Port:     svcPort.Port,
-		Host:     host,
-		Username: user,
-		Password: password,
-		Database: database,
+	creds := Object{
+		"protocol": postgresqlProtocolName,
+		"port":     svcPort.Port,
+		"host":     host,
+		"username": user,
+		"password": password,
+		"database": database,
+		"uri": (&url.URL{
+			Scheme: postgresqlProtocolName,
+			User:   url.UserPassword(user, password),
+			Host:   fmt.Sprintf("%s:%d", host, svcPort.Port),
+			Path:   database,
+		}).String(),
 	}
-	creds.URI = buildURI(creds)
 
-	return &creds, nil
+	return creds, nil
 }

--- a/pkg/minibroker/provider.go
+++ b/pkg/minibroker/provider.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/minibroker/provider.go
+++ b/pkg/minibroker/provider.go
@@ -85,10 +85,10 @@ func (o Object) DigString(key string) (string, error) {
 func (o Object) DigStringAlt(altKeys []string) (string, error) {
 	for _, altKey := range altKeys {
 		valStr, err := o.DigString(altKey)
+		if err == ErrDigNotFound {
+			continue
+		}
 		if err != nil {
-			if err == ErrDigNotFound {
-				continue
-			}
 			return "", err
 		}
 		return valStr, nil
@@ -99,10 +99,10 @@ func (o Object) DigStringAlt(altKeys []string) (string, error) {
 // DigStringOr wraps Object.DigString and returns defaultValue if the value was not found.
 func (o Object) DigStringOr(key string, defaultValue string) (string, error) {
 	str, err := o.DigString(key)
+	if err == ErrDigNotFound {
+		return defaultValue, nil
+	}
 	if err != nil {
-		if err == ErrDigNotFound {
-			return defaultValue, nil
-		}
 		return "", err
 	}
 	return str, nil
@@ -112,10 +112,10 @@ func (o Object) DigStringOr(key string, defaultValue string) (string, error) {
 // keys are found.
 func (o Object) DigStringAltOr(altKeys []string, defaultValue string) (string, error) {
 	str, err := o.DigStringAlt(altKeys)
+	if err == ErrDigNotFound {
+		return defaultValue, nil
+	}
 	if err != nil {
-		if err == ErrDigNotFound {
-			return defaultValue, nil
-		}
 		return "", err
 	}
 	return str, nil

--- a/pkg/minibroker/provider.go
+++ b/pkg/minibroker/provider.go
@@ -80,14 +80,50 @@ func (o Object) DigString(key string) (string, error) {
 	return valStr, nil
 }
 
-// DigStringOr wraps Object.DigString and returns defaultValue if any error is returned from
-// Object.DigString.
-func (o Object) DigStringOr(key string, defaultValue string) string {
+// DigStringAlt digs for the alternative keys. It returns the first found, if any.
+func (o Object) DigStringAlt(altKeys []string) (string, error) {
+	for _, altKey := range altKeys {
+		valStr, err := o.DigString(altKey)
+		if err != nil {
+			switch err {
+			case ErrDigNotFound:
+				continue
+			default:
+				return "", err
+			}
+		}
+		return valStr, nil
+	}
+	return "", ErrDigNotFound
+}
+
+// DigStringOr wraps Object.DigString and returns defaultValue if the value was not found.
+func (o Object) DigStringOr(key string, defaultValue string) (string, error) {
 	str, err := o.DigString(key)
 	if err != nil {
-		return defaultValue
+		switch err {
+		case ErrDigNotFound:
+			return defaultValue, nil
+		default:
+			return "", err
+		}
 	}
-	return str
+	return str, nil
+}
+
+// DigStringAltOr wraps Object.DigStringAlt and returns defaultValue if none of the alternative
+// keys are found.
+func (o Object) DigStringAltOr(altKeys []string, defaultValue string) (string, error) {
+	str, err := o.DigStringAlt(altKeys)
+	if err != nil {
+		switch err {
+		case ErrDigNotFound:
+			return defaultValue, nil
+		default:
+			return "", err
+		}
+	}
+	return str, nil
 }
 
 // BindParams is a specialization of Object for binding parameters, ensuring type checking.

--- a/pkg/minibroker/provider.go
+++ b/pkg/minibroker/provider.go
@@ -80,7 +80,8 @@ func (o Object) DigString(key string) (string, error) {
 	return valStr, nil
 }
 
-// DigStringAlt digs for the alternative keys. It returns the first found, if any.
+// DigStringAlt digs for any of the given keys, returning the first found. It returns an error if
+// none of the alternative keys are found.
 func (o Object) DigStringAlt(altKeys []string) (string, error) {
 	for _, altKey := range altKeys {
 		valStr, err := o.DigString(altKey)

--- a/pkg/minibroker/provider.go
+++ b/pkg/minibroker/provider.go
@@ -17,53 +17,115 @@ limitations under the License.
 package minibroker
 
 import (
-	"encoding/json"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
+// Provider is the interface for the Service Provider. Its methods wrap service-specific logic.
 type Provider interface {
-	Bind(service []corev1.Service, params map[string]interface{}, chartSecrets map[string]interface{}) (*Credentials, error)
+	Bind(
+		service []corev1.Service,
+		bindParams BindParams,
+		provisionParams ProvisionParams,
+		chartSecrets Object,
+	) (Object, error)
 }
 
-type Credentials struct {
-	Protocol string
-	URI      string `json:"uri,omitempty"`
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Host     string `json:"host,omitempty"`
-	Port     int32  `json:"port,omitempty"`
-	Database string `json:"database,omitempty"`
-}
+// Object is a wrapper around map[string]interface{} that implements methods for helping with
+// digging and type asserting.
+type Object map[string]interface{}
 
-// ToMap converts the credentials into the OSB API credentials response
-// see https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#device-object
-// {
-//   "credentials": {
-//     "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-//     "username": "mysqluser",
-//     "password": "pass",
-//     "host": "mysqlhost",
-//     "port": 3306,
-//     "database": "dbname"
-//     }
-// }
-func (c Credentials) ToMap() map[string]interface{} {
-	var result map[string]interface{}
-	j, _ := json.Marshal(c)
-	json.Unmarshal(j, &result)
-	return result
-}
+var (
+	// ErrDigNotFound is the error for a key not found in the Object.
+	ErrDigNotFound = fmt.Errorf("key not found")
+	// ErrDigNotString is the error for a key that is not a string.
+	ErrDigNotString = fmt.Errorf("key is not a string")
+)
 
-func buildURI(c Credentials) string {
-	if c.Database == "" {
-		return fmt.Sprintf("%s://%s:%s@%s:%d",
-			c.Protocol, c.Username, c.Password, c.Host, c.Port)
+// Dig digs the Object based on the provided key.
+// key must be in the format "foo.bar.baz". Each segment represents a level in the Object.
+func (o Object) Dig(key string) (interface{}, bool) {
+	keyParts := strings.Split(key, ".")
+	var part interface{} = o
+	var ok bool
+	for _, keyPart := range keyParts {
+		switch p := part.(type) {
+		case map[string]interface{}:
+			part, ok = p[keyPart]
+			if !ok {
+				return nil, false
+			}
+		case Object:
+			part, ok = p[keyPart]
+			if !ok {
+				return nil, false
+			}
+		default:
+			return nil, false
+		}
 	}
+	return part, ok
+}
 
-	return fmt.Sprintf("%s://%s:%s@%s:%d/%s",
-		c.Protocol, c.Username, c.Password, c.Host, c.Port, c.Database)
+// DigString wraps Object.Dig and type-asserts the found key.
+func (o Object) DigString(key string) (string, error) {
+	val, ok := o.Dig(key)
+	if !ok {
+		return "", ErrDigNotFound
+	}
+	valStr, ok := val.(string)
+	if !ok {
+		return "", ErrDigNotString
+	}
+	return valStr, nil
+}
+
+// DigStringOr wraps Object.DigString and returns defaultValue if any error is returned from
+// Object.DigString.
+func (o Object) DigStringOr(key string, defaultValue string) string {
+	str, err := o.DigString(key)
+	if err != nil {
+		return defaultValue
+	}
+	return str
+}
+
+// BindParams is a new type that wraps Object.
+type BindParams Object
+
+// Dig wraps Object.Dig.
+func (bp BindParams) Dig(key string) (interface{}, bool) {
+	return Object(bp).Dig(key)
+}
+
+// DigString wraps Object.DigString.
+func (bp BindParams) DigString(key string) (string, error) {
+	return Object(bp).DigString(key)
+}
+
+// DigStringOr wraps Object.DigStringOr.
+func (bp BindParams) DigStringOr(key string, defaultValue string) string {
+	return Object(bp).DigStringOr(key, defaultValue)
+}
+
+// ProvisionParams is a new type that wraps Object.
+type ProvisionParams Object
+
+// Dig wraps Object.Dig.
+func (pp ProvisionParams) Dig(key string) (interface{}, bool) {
+	return Object(pp).Dig(key)
+}
+
+// DigString wraps Object.DigString.
+func (pp ProvisionParams) DigString(key string) (string, error) {
+	return Object(pp).DigString(key)
+}
+
+// DigStringOr wraps Object.DigStringOr.
+func (pp ProvisionParams) DigStringOr(key string, defaultValue string) string {
+	return Object(pp).DigStringOr(key, defaultValue)
 }
 
 func buildHostFromService(service corev1.Service) string {

--- a/pkg/minibroker/provider.go
+++ b/pkg/minibroker/provider.go
@@ -27,8 +27,8 @@ import (
 type Provider interface {
 	Bind(
 		service []corev1.Service,
-		bindParams BindParams,
-		provisionParams ProvisionParams,
+		bindParams *BindParams,
+		provisionParams *ProvisionParams,
 		chartSecrets Object,
 	) (Object, error)
 }
@@ -53,13 +53,11 @@ func (o Object) Dig(key string) (interface{}, bool) {
 	for _, keyPart := range keyParts {
 		switch p := part.(type) {
 		case map[string]interface{}:
-			part, ok = p[keyPart]
-			if !ok {
+			if part, ok = p[keyPart]; !ok {
 				return nil, false
 			}
 		case Object:
-			part, ok = p[keyPart]
-			if !ok {
+			if part, ok = p[keyPart]; !ok {
 				return nil, false
 			}
 		default:
@@ -92,40 +90,25 @@ func (o Object) DigStringOr(key string, defaultValue string) string {
 	return str
 }
 
-// BindParams is a new type that wraps Object.
-type BindParams Object
-
-// Dig wraps Object.Dig.
-func (bp BindParams) Dig(key string) (interface{}, bool) {
-	return Object(bp).Dig(key)
+// BindParams is a specialization of Object for binding parameters, ensuring type checking.
+type BindParams struct {
+	Object
 }
 
-// DigString wraps Object.DigString.
-func (bp BindParams) DigString(key string) (string, error) {
-	return Object(bp).DigString(key)
+// NewBindParams constructs a new BindParams.
+func NewBindParams(m map[string]interface{}) *BindParams {
+	return &BindParams{Object: m}
 }
 
-// DigStringOr wraps Object.DigStringOr.
-func (bp BindParams) DigStringOr(key string, defaultValue string) string {
-	return Object(bp).DigStringOr(key, defaultValue)
+// ProvisionParams is a specialization of Object for provisioning parameters, ensuring type
+// checking.
+type ProvisionParams struct {
+	Object
 }
 
-// ProvisionParams is a new type that wraps Object.
-type ProvisionParams Object
-
-// Dig wraps Object.Dig.
-func (pp ProvisionParams) Dig(key string) (interface{}, bool) {
-	return Object(pp).Dig(key)
-}
-
-// DigString wraps Object.DigString.
-func (pp ProvisionParams) DigString(key string) (string, error) {
-	return Object(pp).DigString(key)
-}
-
-// DigStringOr wraps Object.DigStringOr.
-func (pp ProvisionParams) DigStringOr(key string, defaultValue string) string {
-	return Object(pp).DigStringOr(key, defaultValue)
+// NewProvisionParams constructs a new ProvisionParams.
+func NewProvisionParams(m map[string]interface{}) *ProvisionParams {
+	return &ProvisionParams{Object: m}
 }
 
 func buildHostFromService(service corev1.Service) string {

--- a/pkg/minibroker/provider.go
+++ b/pkg/minibroker/provider.go
@@ -86,12 +86,10 @@ func (o Object) DigStringAlt(altKeys []string) (string, error) {
 	for _, altKey := range altKeys {
 		valStr, err := o.DigString(altKey)
 		if err != nil {
-			switch err {
-			case ErrDigNotFound:
+			if err == ErrDigNotFound {
 				continue
-			default:
-				return "", err
 			}
+			return "", err
 		}
 		return valStr, nil
 	}
@@ -102,12 +100,10 @@ func (o Object) DigStringAlt(altKeys []string) (string, error) {
 func (o Object) DigStringOr(key string, defaultValue string) (string, error) {
 	str, err := o.DigString(key)
 	if err != nil {
-		switch err {
-		case ErrDigNotFound:
+		if err == ErrDigNotFound {
 			return defaultValue, nil
-		default:
-			return "", err
 		}
+		return "", err
 	}
 	return str, nil
 }
@@ -117,12 +113,10 @@ func (o Object) DigStringOr(key string, defaultValue string) (string, error) {
 func (o Object) DigStringAltOr(altKeys []string, defaultValue string) (string, error) {
 	str, err := o.DigStringAlt(altKeys)
 	if err != nil {
-		switch err {
-		case ErrDigNotFound:
+		if err == ErrDigNotFound {
 			return defaultValue, nil
-		default:
-			return "", err
 		}
+		return "", err
 	}
 	return str, nil
 }

--- a/pkg/minibroker/provider.go
+++ b/pkg/minibroker/provider.go
@@ -47,10 +47,16 @@ var (
 // Dig digs the Object based on the provided key.
 // key must be in the format "foo.bar.baz". Each segment represents a level in the Object.
 func (o Object) Dig(key string) (interface{}, bool) {
+	if key == "" {
+		return nil, false
+	}
 	keyParts := strings.Split(key, ".")
 	var part interface{} = o
 	var ok bool
 	for _, keyPart := range keyParts {
+		if keyPart == "" {
+			return nil, false
+		}
 		switch p := part.(type) {
 		case map[string]interface{}:
 			if part, ok = p[keyPart]; !ok {

--- a/pkg/minibroker/provider_test.go
+++ b/pkg/minibroker/provider_test.go
@@ -44,6 +44,36 @@ func TestObjectDig(t *testing.T) {
 			false,
 		},
 		{
+			Object{"foo": Object{"bar": "baz"}},
+			"",
+			nil,
+			false,
+		},
+		{
+			Object{"foo": Object{"": "baz"}},
+			"foo.",
+			nil,
+			false,
+		},
+		{
+			Object{"foo": Object{"bar": "baz"}},
+			"foo.",
+			nil,
+			false,
+		},
+		{
+			Object{"foo": Object{"bar": "baz"}},
+			"foo..bar",
+			nil,
+			false,
+		},
+		{
+			Object{"": Object{"bar": "baz"}},
+			".bar",
+			nil,
+			false,
+		},
+		{
 			Object{"foo": "baz"},
 			"foo",
 			"baz",

--- a/pkg/minibroker/provider_test.go
+++ b/pkg/minibroker/provider_test.go
@@ -98,10 +98,54 @@ func TestObjectDigString(t *testing.T) {
 	for _, tt := range tests {
 		val, err := tt.obj.DigString(tt.key)
 		if err != tt.expectedErr {
-			t.Errorf("Object.Dig(%s): expected err %v, actual err %v", tt.key, tt.expectedErr, err)
+			t.Errorf("Object.DigString(%s): expected err %v, actual err %v", tt.key, tt.expectedErr, err)
 		}
 		if val != tt.expectedVal {
-			t.Errorf("Object.Dig(%s): expected val %v, actual val %v", tt.key, tt.expectedVal, val)
+			t.Errorf("Object.DigString(%s): expected val %v, actual val %v", tt.key, tt.expectedVal, val)
+		}
+	}
+}
+
+func TestObjectDigStringAlt(t *testing.T) {
+	tests := []struct {
+		obj         Object
+		altKeys     []string
+		expectedVal string
+		expectedErr error
+	}{
+		{
+			Object{"foo": "baz"},
+			[]string{"bar", "baz"},
+			"",
+			ErrDigNotFound,
+		},
+		{
+			Object{"foo": 3},
+			[]string{"bar", "foo"},
+			"",
+			ErrDigNotString,
+		},
+		{
+			Object{"foo": Object{"bar": "baz"}},
+			[]string{"foo", "foo.bar"},
+			"",
+			ErrDigNotString,
+		},
+		{
+			Object{"foo": Object{"bar": "baz"}},
+			[]string{"foo.foo", "foo.bar"},
+			"baz",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		val, err := tt.obj.DigStringAlt(tt.altKeys)
+		if err != tt.expectedErr {
+			t.Errorf("Object.DigStringAlt(%v): expected err %v, actual err %v", tt.altKeys, tt.expectedErr, err)
+		}
+		if val != tt.expectedVal {
+			t.Errorf("Object.DigStringAlt(%v): expected val %v, actual val %v", tt.altKeys, tt.expectedVal, val)
 		}
 	}
 }
@@ -112,25 +156,80 @@ func TestObjectDigStringOr(t *testing.T) {
 		key         string
 		defaultVal  string
 		expectedVal string
+		expectedErr error
 	}{
+		{
+			Object{"foo": 1},
+			"foo",
+			"default",
+			"",
+			ErrDigNotString,
+		},
 		{
 			Object{"foo": "baz"},
 			"bar",
 			"default",
 			"default",
+			nil,
 		},
 		{
 			Object{"foo": "baz"},
 			"foo",
 			"default",
 			"baz",
+			nil,
 		},
 	}
 
 	for _, tt := range tests {
-		val := tt.obj.DigStringOr(tt.key, tt.defaultVal)
+		val, err := tt.obj.DigStringOr(tt.key, tt.defaultVal)
+		if err != tt.expectedErr {
+			t.Errorf("Object.DigStringOr(%s): expected err %v, actual err %v", tt.key, tt.expectedErr, err)
+		}
 		if val != tt.expectedVal {
-			t.Errorf("Object.Dig(%s): expected val %v, actual val %v", tt.key, tt.expectedVal, val)
+			t.Errorf("Object.DigStringOr(%s): expected val %v, actual val %v", tt.key, tt.expectedVal, val)
+		}
+	}
+}
+
+func TestObjectDigStringAltOr(t *testing.T) {
+	tests := []struct {
+		obj         Object
+		altKeys     []string
+		defaultVal  string
+		expectedVal string
+		expectedErr error
+	}{
+		{
+			Object{"foo": 1},
+			[]string{"bar", "foo"},
+			"default",
+			"",
+			ErrDigNotString,
+		},
+		{
+			Object{"foo": "baz"},
+			[]string{"bar", "baz"},
+			"default",
+			"default",
+			nil,
+		},
+		{
+			Object{"foo": "baz"},
+			[]string{"bar", "foo"},
+			"default",
+			"baz",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		val, err := tt.obj.DigStringAltOr(tt.altKeys, tt.defaultVal)
+		if err != tt.expectedErr {
+			t.Errorf("Object.DigStringAltOr(%v): expected err %v, actual err %v", tt.altKeys, tt.expectedErr, err)
+		}
+		if val != tt.expectedVal {
+			t.Errorf("Object.DigStringAltOr(%v): expected val %v, actual val %v", tt.altKeys, tt.expectedVal, val)
 		}
 	}
 }

--- a/pkg/minibroker/provider_test.go
+++ b/pkg/minibroker/provider_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package minibroker
+
+import "testing"
+
+func TestObjectDig(t *testing.T) {
+	tests := []struct {
+		obj         Object
+		key         string
+		expectedVal interface{}
+		expectedOk  bool
+	}{
+		{
+			Object{"foo": "baz"},
+			"bar",
+			nil,
+			false,
+		},
+		{
+			Object{"foo": Object{"bar": "baz"}},
+			"foo.foo",
+			nil,
+			false,
+		},
+		{
+			Object{"foo": Object{"bar": "baz"}},
+			"foo.bar.bar",
+			nil,
+			false,
+		},
+		{
+			Object{"foo": "baz"},
+			"foo",
+			"baz",
+			true,
+		},
+		{
+			Object{"foo": Object{"bar": "baz"}},
+			"foo.bar",
+			"baz",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		val, ok := tt.obj.Dig(tt.key)
+		if ok != tt.expectedOk {
+			t.Errorf("Object.Dig(%s): expected ok %v, actual ok %v", tt.key, tt.expectedOk, ok)
+		}
+		if val != tt.expectedVal {
+			t.Errorf("Object.Dig(%s): expected val %v, actual val %v", tt.key, tt.expectedVal, val)
+		}
+	}
+}
+
+func TestObjectDigString(t *testing.T) {
+	tests := []struct {
+		obj         Object
+		key         string
+		expectedVal string
+		expectedErr error
+	}{
+		{
+			Object{"foo": "baz"},
+			"bar",
+			"",
+			ErrDigNotFound,
+		},
+		{
+			Object{"foo": 3},
+			"foo",
+			"",
+			ErrDigNotString,
+		},
+		{
+			Object{"foo": Object{"bar": "baz"}},
+			"foo.bar",
+			"baz",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		val, err := tt.obj.DigString(tt.key)
+		if err != tt.expectedErr {
+			t.Errorf("Object.Dig(%s): expected err %v, actual err %v", tt.key, tt.expectedErr, err)
+		}
+		if val != tt.expectedVal {
+			t.Errorf("Object.Dig(%s): expected val %v, actual val %v", tt.key, tt.expectedVal, val)
+		}
+	}
+}
+
+func TestObjectDigStringOr(t *testing.T) {
+	tests := []struct {
+		obj         Object
+		key         string
+		defaultVal  string
+		expectedVal string
+	}{
+		{
+			Object{"foo": "baz"},
+			"bar",
+			"default",
+			"default",
+		},
+		{
+			Object{"foo": "baz"},
+			"foo",
+			"default",
+			"baz",
+		},
+	}
+
+	for _, tt := range tests {
+		val := tt.obj.DigStringOr(tt.key, tt.defaultVal)
+		if val != tt.expectedVal {
+			t.Errorf("Object.Dig(%s): expected val %v, actual val %v", tt.key, tt.expectedVal, val)
+		}
+	}
+}

--- a/pkg/minibroker/rabbitmq.go
+++ b/pkg/minibroker/rabbitmq.go
@@ -53,7 +53,11 @@ func (p RabbitmqProvider) Bind(
 		return nil, errors.Errorf("no amqp port found")
 	}
 
-	username := provisionParams.DigStringOr("rabbitmq.username", defaultRabbitmqUsername)
+	user, err := provisionParams.DigStringOr("rabbitmq.username", defaultRabbitmqUsername)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get username: %w", err)
+	}
+
 	password, err := chartSecrets.DigString("rabbitmq-password")
 	if err != nil {
 		switch err {
@@ -71,11 +75,11 @@ func (p RabbitmqProvider) Bind(
 		"protocol": amqpProtocolName,
 		"port":     svcPort.Port,
 		"host":     host,
-		"username": username,
+		"username": user,
 		"password": password,
 		"uri": (&url.URL{
 			Scheme: amqpProtocolName,
-			User:   url.UserPassword(username, password),
+			User:   url.UserPassword(user, password),
 			Host:   fmt.Sprintf("%s:%d", host, svcPort.Port),
 		}).String(),
 	}

--- a/pkg/minibroker/rabbitmq.go
+++ b/pkg/minibroker/rabbitmq.go
@@ -33,8 +33,8 @@ type RabbitmqProvider struct{}
 
 func (p RabbitmqProvider) Bind(
 	services []corev1.Service,
-	_ BindParams,
-	provisionParams ProvisionParams,
+	_ *BindParams,
+	provisionParams *ProvisionParams,
 	chartSecrets Object,
 ) (Object, error) {
 	if len(services) == 0 {

--- a/pkg/minibroker/rabbitmq.go
+++ b/pkg/minibroker/rabbitmq.go
@@ -60,14 +60,7 @@ func (p RabbitmqProvider) Bind(
 
 	password, err := chartSecrets.DigString("rabbitmq-password")
 	if err != nil {
-		switch err {
-		case ErrDigNotFound:
-			return nil, fmt.Errorf("password not found in secret keys")
-		case ErrDigNotString:
-			return nil, fmt.Errorf("password not a string")
-		default:
-			return nil, err
-		}
+		return nil, fmt.Errorf("failed to get password: %w", err)
 	}
 
 	host := buildHostFromService(service)

--- a/pkg/minibroker/redis.go
+++ b/pkg/minibroker/redis.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/minibroker/redis.go
+++ b/pkg/minibroker/redis.go
@@ -30,8 +30,8 @@ type RedisProvider struct{}
 
 func (p RedisProvider) Bind(
 	services []corev1.Service,
-	_ BindParams,
-	_ ProvisionParams,
+	_ *BindParams,
+	_ *ProvisionParams,
 	chartSecrets Object,
 ) (Object, error) {
 	var masterSvc *corev1.Service

--- a/pkg/minibroker/redis.go
+++ b/pkg/minibroker/redis.go
@@ -54,14 +54,7 @@ func (p RedisProvider) Bind(
 
 	password, err := chartSecrets.DigString("redis-password")
 	if err != nil {
-		switch err {
-		case ErrDigNotFound:
-			return nil, fmt.Errorf("password not found in secret keys")
-		case ErrDigNotString:
-			return nil, fmt.Errorf("password not a string")
-		default:
-			return nil, err
-		}
+		return nil, fmt.Errorf("failed to get password: %w", err)
 	}
 
 	creds := Object{


### PR DESCRIPTION
This refactor improves the `Provider.Bind` logic by being clearer on what parameters are used for finding the expected keys and by introducing new types wrapping `map[string]interface{}` for dealing with repetitive actions.