### PR TITLE
fix: missing cache volume

### DIFF
--- a/charts/minibroker/templates/deployment.yaml
+++ b/charts/minibroker/templates/deployment.yaml
@@ -75,10 +75,14 @@ spec:
           periodSeconds: 15
           failureThreshold: 2
         volumeMounts:
+        - name: cache
+          mountPath: /home/minibroker/.cache
         - name: provisioning-settings
           mountPath: {{ $configPath | quote}}
           readOnly: true
       volumes:
+      - name: cache
+        emptyDir: {}
       - name: provisioning-settings
         configMap:
           name: {{ printf "%s-provisioning-settings" .Release.Name | quote }}


### PR DESCRIPTION
Since we have a read-only root filesystem, we missed the cache volume. In some systems, it will be enforced and make Minibroker fail to download the repository index.