### PR TITLE
feat: add optional docker buildx

### DIFF
--- a/build/image.sh
+++ b/build/image.sh
@@ -25,7 +25,7 @@ if [[ "${BUILD_IN_MINIKUBE}" == "1" ]]; then
   eval $(minikube -p minikube docker-env)
 fi
 
-docker build \
+docker ${USE_BUILDX:+buildx} build \
   --tag "${IMAGE}:${TAG}" \
   ${BUILDER_IMAGE:+--build-arg "BUILDER_IMAGE=${BUILDER_IMAGE}"} \
   ${DOWNLOADER_IMAGE:+--build-arg "DOWNLOADER_IMAGE=${DOWNLOADER_IMAGE}"} \


### PR DESCRIPTION
`docker buildx` speeds the image build considerably. This PR adds an option to use it. It's not the default behaviour as it's still an experimental docker feature and not part of the stable release. It's useful for quicker development iteration.