### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,10 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-      
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/tests/integration/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "gomod"
+  directory: "/tests/integration/"
+  schedule:
+    interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/tests/integration/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This configures github to automatically propose PRs to bump gomod dependencies.

More background at https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically and https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

See sample PRs created in fork https://github.com/orange-cloudfoundry/minibroker/pulls

fixes #123

